### PR TITLE
eslint: Add ignoreComments to max-len rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -39,7 +39,7 @@
       "afterColon": true
     }],
     "keyword-spacing": 2,
-    "max-len": [2, 80, 4],
+    "max-len": [2, 80, 4, { "ignoreComments": true }],
     "no-multi-spaces": [2],
     "no-undef": [2],
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],


### PR DESCRIPTION
This rule is needed to bypass linting of long comment
blocks, specifically jsdocs. Modules that have very
long name paths/methods cannot be properly linked with
the @link tag, as it does not allow breaking spaces.

Semver: minor